### PR TITLE
concurrency and contexts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["async", "job", "dependency", "graph"]
 categories = ["algorithms", "asynchronous", "concurrency"]
 
 [dependencies]
-async-trait = "0.1"
+downcast-rs = "1.2"
 
 [dev-dependencies]
 async-std = { version = "1.6", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ categories = ["algorithms", "asynchronous", "concurrency"]
 
 [dependencies]
 downcast-rs = "1.2"
+futures = "0.3"
+num_cpus = "1.13"
 
 [dev-dependencies]
 async-std = { version = "1.6", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-jobs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Bobby Reynolds <bobby@reynoldsbd.net>"]
 edition = "2018"
 description = "Asynchronous job orchestration for Rust"


### PR DESCRIPTION
Implement concurrent job execution using `FuturesUnordered` (#1)

Make jobs generic over context type `C` (#7)

Refactor APIs to use visitor(ish) pattern `PlanBuilder`. Eliminates `async-trait` dependency, reduces number of allocations needed to use this API, and IMO is more ergonomic.